### PR TITLE
Release 0.2.0

### DIFF
--- a/Editor/AddressableIdsGenerator.cs
+++ b/Editor/AddressableIdsGenerator.cs
@@ -252,8 +252,17 @@ namespace GameLoversEditor.AddressablesExtensions
 
 		private static void GenerateAddressEnums(StringBuilder stringBuilder, IReadOnlyList<AddressableAssetEntry> assetList)
 		{
+			var addedNames = new List<string>();
+			
 			for (var i = 0; i < assetList.Count; i++)
 			{
+				var name = GetCleanName(assetList[i].address, true);
+				var filetype = assetList[i].address.Substring(assetList[i].address.LastIndexOf('.') + 1);
+
+				name = addedNames.Contains(name) ? $"{name}_{filetype}" : name;
+				
+				addedNames.Add(name);
+				
 				stringBuilder.Append("\t\t");
 				stringBuilder.Append(GetCleanName(assetList[i].address, true));
 				stringBuilder.Append(i + 1 == assetList.Count ? "\n" : ",\n");

--- a/Editor/AddressableIdsGenerator.cs
+++ b/Editor/AddressableIdsGenerator.cs
@@ -133,6 +133,11 @@ namespace GameLoversEditor.AddressablesExtensions
 			stringBuilder.AppendLine("\t\t{");
 			stringBuilder.AppendLine("\t\t\treturn _addressableLabelMap[label];");
 			stringBuilder.AppendLine("\t\t}");
+			stringBuilder.AppendLine("");
+			stringBuilder.AppendLine($"\t\tpublic static string ToLabelString(this AddressableLabel label)");
+			stringBuilder.AppendLine("\t\t{");
+			stringBuilder.AppendLine("\t\t\treturn _addressableLabels[(int) label];");
+			stringBuilder.AppendLine("\t\t}");
 		}
 
 		private static void GenerateLabelMap(StringBuilder stringBuilder, IDictionary<string, IList<AddressableAssetEntry>> assetLabelMap)

--- a/Editor/AddressableIdsGenerator.cs
+++ b/Editor/AddressableIdsGenerator.cs
@@ -288,6 +288,7 @@ namespace GameLoversEditor.AddressablesExtensions
 			name = name.Replace("/", charReplace);
 			name = name.Replace("\\", charReplace);
 			name = name.Replace(" ", charReplace);
+			name = name.Replace("-", charReplace);
 
 			return name;
 		}

--- a/Editor/AddressableIdsGenerator.cs
+++ b/Editor/AddressableIdsGenerator.cs
@@ -1,14 +1,14 @@
+using GameLovers.AssetsImporter;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using GameLovers.AddressablesExtensions;
 using UnityEditor;
 using UnityEditor.AddressableAssets;
 using UnityEditor.AddressableAssets.Settings;
 
 // ReSharper disable once CheckNamespace
 
-namespace GameLoversEditor.AddressablesExtensions
+namespace GameLoversEditor.AssetsImporter
 {
 	/// <summary>
 	/// Generates the Addressable Ids into a script file

--- a/Editor/AddressableIdsGenerator.cs
+++ b/Editor/AddressableIdsGenerator.cs
@@ -16,6 +16,7 @@ namespace GameLoversEditor.AddressablesExtensions
 	public static class AddressableIdsGenerator
 	{
 		private const string _objectName = "AddressableId";
+		private const string _namespace = "GameLovers.Game.Ids";
 		
 		[MenuItem("Tools/Generate AddressableIds")]
 		private static void GenerateAddressableIds()
@@ -71,7 +72,6 @@ namespace GameLoversEditor.AddressablesExtensions
 			var paths = new List<string>();
 
 			ProcessData(assetList, labelMap, paths);
-			
 			stringBuilder.AppendLine("/* AUTO GENERATED CODE */");
 			stringBuilder.AppendLine("");
 			stringBuilder.AppendLine("using System.Collections.Generic;");
@@ -81,7 +81,7 @@ namespace GameLoversEditor.AddressablesExtensions
 			stringBuilder.AppendLine("// ReSharper disable InconsistentNaming");
 			stringBuilder.AppendLine("// ReSharper disable once CheckNamespace");
 			stringBuilder.AppendLine("");
-			stringBuilder.AppendLine("namespace Ids");
+			stringBuilder.AppendLine($"namespace {_namespace}Ids");
 			stringBuilder.AppendLine("{");
 			
 			stringBuilder.AppendLine($"\tpublic enum {_objectName}");
@@ -262,7 +262,7 @@ namespace GameLoversEditor.AddressablesExtensions
 				name = addedNames.Contains(name) ? $"{name}_{filetype}" : name;
 				
 				addedNames.Add(name);
-				
+
 				stringBuilder.Append("\t\t");
 				stringBuilder.Append(GetCleanName(assetList[i].address, true));
 				stringBuilder.Append(i + 1 == assetList.Count ? "\n" : ",\n");

--- a/Editor/AssetConfigsImporter.cs
+++ b/Editor/AssetConfigsImporter.cs
@@ -1,0 +1,132 @@
+using GameLovers;
+using GameLovers.AssetsImporter;
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+// ReSharper disable once CheckNamespace
+
+namespace GameLoversEditor.AssetsImporter
+{
+	/// <summary>
+	/// Interface to import a single Scriptable Object.
+	/// All the process is done in Editor time.
+	/// </summary> for this interface
+	/// <remarks>
+	/// Implement this interface to import a single Asset type weak references into a scriptable object.
+	/// </remarks>
+	public interface IScriptableObjectImporter
+	{
+		/// <summary>
+		/// The type of scriptable object that will be saved. Helper to cast the scriptable object type at runtime
+		/// </summary>
+		Type ScriptableObjectType { get; }
+	}
+
+	/// <summary>
+	/// Asset importers allow to create custom in editor time processors of specific assets in the project.
+	/// They import their correspondent asset type and map it inside a container with their respective id.
+	/// </summary>
+	public interface IAssetConfigsImporter : IScriptableObjectImporter
+	{
+		/// <summary>
+		/// Imports all assets belonging to this asset config scope into a defined container
+		/// </summary>
+		void Import();
+	}
+
+	/// <inheritdoc cref="IAssetConfigsImporter"/>
+	/// <remarks>
+	/// It will save the asset data into a scriptable object of <typeparamref name="TScriptableObject"/> type
+	/// </remarks>
+	public abstract class AssetsConfigsImporter<TId, TAsset, TScriptableObject> : IAssetConfigsImporter
+		where TId : struct
+		where TScriptableObject : AssetConfigsScriptableObject<TId, TAsset>
+	{
+		/// <inheritdoc />
+		public Type ScriptableObjectType => typeof(TScriptableObject);
+
+		/// <summary>
+		/// AssetType being referenced in the configs importer to be serialized
+		/// </summary>
+		public virtual Type AssetType => typeof(TAsset);
+
+		/// <inheritdoc />
+		public void Import()
+		{
+			var type = typeof(TScriptableObject);
+			var soAssets = AssetDatabase.FindAssets($"t:{type.Name}");
+			var scriptableObject = soAssets.Length > 0
+				                       ? AssetDatabase.LoadAssetAtPath<TScriptableObject>(AssetDatabase.GUIDToAssetPath(soAssets[0]))
+				                       : ScriptableObject.CreateInstance<TScriptableObject>();
+
+			if (soAssets.Length == 0)
+			{
+				AssetDatabase.CreateAsset(scriptableObject, $"Assets/{type.Name}.asset");
+			}
+
+			var assetGuids = new List<string>(AssetDatabase.FindAssets($"t:{AssetType.Name}", new[]
+			{
+				scriptableObject.AssetsFolderPath
+			}));
+			var assetsPaths = assetGuids.ConvertAll(a => AssetDatabase.GUIDToAssetPath(a));
+
+			scriptableObject.Configs.Clear();
+			scriptableObject.Configs.AddRange(OnImportIds(scriptableObject, assetGuids, assetsPaths));
+			OnImportComplete(scriptableObject);
+			EditorUtility.SetDirty(scriptableObject);
+			
+			Debug.Log($"Finished importing asset data of '{AssetType.Name}' type with '{typeof(TId).Name}' as identifier.\n" +
+			          $"To: '{typeof(TScriptableObject).Name}' - From '{scriptableObject.AssetsFolderPath}' ");
+		}
+		
+		protected virtual TId[] GetIds()
+		{
+			return Enum.GetValues(typeof(TId)) as TId[];
+		}
+
+		protected virtual string IdPattern(TId id)
+		{
+			return id.ToString();
+		}
+
+		protected virtual List<Pair<TId, AssetReference>> OnImportIds(TScriptableObject scriptableObject,
+		                                                              List<string> assetGuids, 
+		                                                              List<string> assetsPaths)
+		{
+			var ids = GetIds();
+			var list = new List<Pair<TId, AssetReference>>(ids.Length);
+
+			for (var i = 0; i < ids.Length; i++)
+			{
+				var indexOf = IndexOfId(IdPattern(ids[i]), assetsPaths);
+
+				if (indexOf < 0)
+				{
+					continue;
+				}
+
+				list.Add(new Pair<TId, AssetReference>(ids[i], new AssetReference(assetGuids[indexOf])));
+			}
+
+			return list;
+		}
+
+		protected int IndexOfId(string id, IList<string> assetsPath)
+		{
+			for (var i = 0; i < assetsPath.Count; i++)
+			{
+				if (assetsPath[i].Contains($"/{id}."))
+				{
+					return i;
+				}
+			}
+
+			return -1;
+		}
+
+		protected virtual void OnImportComplete(TScriptableObject scriptableObject) { }
+	}
+}

--- a/Editor/AssetConfigsImporter.cs.meta
+++ b/Editor/AssetConfigsImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1495ba977d6127d44a7c360881d50085
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AssetsImporter.cs
+++ b/Editor/AssetsImporter.cs
@@ -1,0 +1,32 @@
+using UnityEditor;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+
+namespace GameLoversEditor.AssetsImporter
+{
+	/// <summary>
+	/// Scriptable Object tool to import all or specific assets data
+	/// </summary>
+	[CreateAssetMenu(fileName = "AssetsImporter", menuName = "ScriptableObjects/Editor/AssetsImporter")]
+	public class AssetsImporter : ScriptableObject
+	{
+		[MenuItem("Tools/Assets Importer/Select AssetsImporter.asset")]
+		private static void SelectAssetsImporter()
+		{
+			var assets = AssetDatabase.FindAssets($"t:{nameof(AssetsImporter)}");
+			var scriptableObject = assets.Length > 0 ? 
+				                       AssetDatabase.LoadAssetAtPath<AssetsImporter>(AssetDatabase.GUIDToAssetPath(assets[0])) :
+				                       CreateInstance<AssetsImporter>();
+
+			if (assets.Length == 0)
+			{
+				AssetDatabase.CreateAsset(scriptableObject, $"Assets/{nameof(AssetsImporter)}.asset");
+				AssetDatabase.SaveAssets();
+				AssetDatabase.Refresh();
+			}
+
+			Selection.activeObject = scriptableObject;
+		}
+	}
+}

--- a/Editor/AssetsImporter.cs.meta
+++ b/Editor/AssetsImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ddcdc2601157d842bc928d99cf16918
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AssetsToolImporter.cs
+++ b/Editor/AssetsToolImporter.cs
@@ -1,0 +1,149 @@
+using GameLovers.AssetsImporter;
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+
+namespace GameLoversEditor.AssetsImporter
+{
+	/// <summary>
+	/// Customizes the visual inspector of the importing tool <seealso cref="AssetsImporter"/>
+	/// </summary>
+	[CustomEditor(typeof(AssetsImporter))]
+	public class AssetsToolImporter : Editor
+	{
+		private static List<ImportData> _importers;
+		
+		private void Awake()
+		{
+			_importers = GetAllImporters();
+		}
+		
+		[DidReloadScripts]
+		public static void OnCompileScripts()
+		{
+			_importers = GetAllImporters();
+		}
+		
+		[MenuItem("Tools/Assets Importer/Import Assets Data")]
+		private static void ImportAllGoogleSheetData()
+		{
+			_importers = GetAllImporters();
+			
+			foreach (var importer in _importers)
+			{
+				importer.Importer.Import();
+			}
+			
+			AssetDatabase.SaveAssets();
+			AssetDatabase.Refresh();
+		}
+		
+		/// <inheritdoc />
+		public override void OnInspectorGUI()
+		{		if (_importers == null)
+			{
+				// Not yet initialized. Will initialized as soon has all scripts finish compiling
+				return;
+			}
+
+			var typeCheck = typeof(IScriptableObjectImporter);
+			var tool = (AssetsImporter) target;
+			
+			if (GUILayout.Button("Import Assets Data"))
+			{
+				foreach (var importer in _importers)
+				{
+					importer.Importer.Import();
+				}
+				AssetDatabase.SaveAssets();
+				AssetDatabase.Refresh();
+			}
+
+			foreach (var importer in _importers)
+			{
+				EditorGUILayout.Space();
+				EditorGUILayout.BeginHorizontal();
+				EditorGUILayout.PrefixLabel(importer.Type.Name);
+				
+				if (GUILayout.Button("Update Path"))
+				{
+					var scriptableObject = GetScriptableObject(importer);
+
+					var path = EditorUtility.OpenFolderPanel("Select Folder Path", scriptableObject.AssetsFolderPath,
+					                                         "");
+					scriptableObject.AssetsFolderPath = path.Substring(path.IndexOf("Assets/", StringComparison.Ordinal));
+					
+					importer.Importer.Import();
+					AssetDatabase.SaveAssets();
+					AssetDatabase.Refresh();
+				}
+				
+				EditorGUILayout.EndHorizontal();
+				EditorGUILayout.BeginHorizontal();
+				
+				if (GUILayout.Button("Import"))
+				{
+					importer.Importer.Import();
+					AssetDatabase.SaveAssets();
+					AssetDatabase.Refresh();
+				}
+				if(typeCheck.IsAssignableFrom(importer.Type) && GUILayout.Button("Select Object"))
+				{
+					Selection.activeObject = GetScriptableObject(importer);
+				}
+				EditorGUILayout.EndHorizontal();
+			}
+		}
+		
+		private static List<ImportData> GetAllImporters()
+		{
+			var importerInterface = typeof(IAssetConfigsImporter);
+			var importers = new List<ImportData>();
+			
+			foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+			{
+				foreach (var type in assembly.GetTypes())
+				{
+					if (!type.IsAbstract && !type.IsInterface && importerInterface.IsAssignableFrom(type))
+					{
+						importers.Add(new ImportData
+						{
+							Type = type,
+							Importer = Activator.CreateInstance(type) as IAssetConfigsImporter
+						});
+					}
+				}
+			}
+
+			return importers;
+		}
+
+		private static AssetConfigsScriptableObject GetScriptableObject(ImportData data)
+		{
+			var scriptableObjectType = data.Importer.ScriptableObjectType;
+			var assets = AssetDatabase.FindAssets($"t:{scriptableObjectType?.Name}");
+			var scriptableObject = assets.Length > 0 ? 
+				                       AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(assets[0]), scriptableObjectType) :
+				                       CreateInstance(scriptableObjectType);
+
+			if (assets.Length == 0 && scriptableObjectType != null)
+			{
+				AssetDatabase.CreateAsset(scriptableObject, $"Assets/{scriptableObjectType.Name}.asset");
+				AssetDatabase.SaveAssets();
+				AssetDatabase.Refresh();
+			}
+
+			return scriptableObject as AssetConfigsScriptableObject;
+		}
+
+		private struct ImportData
+		{
+			public Type Type;
+			public IAssetConfigsImporter Importer;
+		}
+	}
+}

--- a/Editor/AssetsToolImporter.cs.meta
+++ b/Editor/AssetsToolImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c120a39058a33ed4b98258750ecf41ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/GameLovers.AddressablesExtensions.Editor.asmdef
+++ b/Editor/GameLovers.AddressablesExtensions.Editor.asmdef
@@ -1,9 +1,11 @@
 {
     "name": "GameLovers.AddressablesExtensions.Editor",
+    "rootNamespace": "",
     "references": [
         "GUID:9e24947de15b9834991c9d8411ea37cf",
         "GUID:69448af7b92c7f342b298e06a37122aa",
-        "GUID:ffab5256b265d45fa9fb86697af7ee2b"
+        "GUID:ffab5256b265d45fa9fb86697af7ee2b",
+        "GUID:22c6cdfa54ae844a9a9eda2f0014b020"
     ],
     "includePlatforms": [
         "Editor"

--- a/Runtime/AddressableConfig.cs
+++ b/Runtime/AddressableConfig.cs
@@ -29,6 +29,29 @@ namespace GameLovers.AddressablesExtensions
 			AssetType = assetType;
 			Labels = new ReadOnlyCollection<string>(labels);
 		}
+
+		/// <summary>
+		/// If this <see cref="AddressableConfig"/> is a config from a scene, it will returns the scene name.
+		/// </summary>
+		/// <exception cref="InvalidOperationException">
+		/// Thrown if this <see cref="AddressableConfig"/> is not a config from a scene
+		/// </exception>
+		public string GetSceneName()
+		{
+			if (AssetType != typeof(UnityEngine.SceneManagement.Scene))
+			{
+				throw new InvalidOperationException($"This {nameof(AddressableConfig)} is not of a " +
+				                                    $"{typeof(UnityEngine.SceneManagement.Scene)} config type. It's of {AssetType.Name} type.");
+			}
+
+			var index = Address.LastIndexOf("/", StringComparison.Ordinal);
+			var typeIndex = Address.LastIndexOf(".", StringComparison.Ordinal);
+
+			index = index < 0 ? 0 : index + 1;
+			typeIndex = typeIndex < index ? Address.Length : typeIndex;
+
+			return Address.Substring(index, typeIndex - index);
+		}
 	}
 
 	/// <summary>

--- a/Runtime/AddressableConfig.cs
+++ b/Runtime/AddressableConfig.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 
 // ReSharper disable once CheckNamespace
 
-namespace GameLovers.AddressablesExtensions
+namespace GameLovers.AssetsImporter
 {
 	/// <summary>
 	/// Represents a configuration of an Addressable with all it's important data
@@ -19,7 +19,7 @@ namespace GameLovers.AddressablesExtensions
 		public string AssetFileType;
 		public Type AssetType;
 		public ReadOnlyCollection<string> Labels;
-		
+
 		public AddressableConfig(int id, string address, string path, Type assetType, string[] labels)
 		{
 			Id = id;
@@ -41,7 +41,7 @@ namespace GameLovers.AddressablesExtensions
 			if (AssetType != typeof(UnityEngine.SceneManagement.Scene))
 			{
 				throw new InvalidOperationException($"This {nameof(AddressableConfig)} is not of a " +
-				                                    $"{typeof(UnityEngine.SceneManagement.Scene)} config type. It's of {AssetType.Name} type.");
+													$"{typeof(UnityEngine.SceneManagement.Scene)} config type. It's of {AssetType.Name} type.");
 			}
 
 			var index = Address.LastIndexOf("/", StringComparison.Ordinal);

--- a/Runtime/AddressablesAssetLoader.cs
+++ b/Runtime/AddressablesAssetLoader.cs
@@ -7,7 +7,7 @@ using UnityEngine.SceneManagement;
 
 // ReSharper disable once CheckNamespace
 
-namespace GameLovers.AddressablesExtensions
+namespace GameLovers.AssetsImporter
 {
 	/// <summary>
 	/// The asset loader to use with Addressables
@@ -15,9 +15,9 @@ namespace GameLovers.AddressablesExtensions
 	public class AddressablesAssetLoader : IAssetLoader, ISceneLoader
 	{
 		/// <inheritdoc />
-		public async Task<T> LoadAssetAsync<T>(string path)
-		{			
-			var operation = Addressables.LoadAssetAsync<T>(path);
+		public async Task<T> LoadAssetAsync<T>(object key)
+		{
+			var operation = Addressables.LoadAssetAsync<T>(key);
 
 			await operation.Task;
 
@@ -25,47 +25,41 @@ namespace GameLovers.AddressablesExtensions
 			{
 				throw operation.OperationException;
 			}
-			
+
 			return operation.Result;
 		}
 
 		/// <inheritdoc />
-		public async Task<GameObject> InstantiatePrefabAsync(string path, Transform parent, bool instantiateInWorldSpace)
+		public async Task<GameObject> InstantiateAsync(object key, Transform parent, bool instantiateInWorldSpace)
 		{
-			return await InstantiatePrefabAsync(path, new InstantiationParameters(parent, instantiateInWorldSpace));
+			return await InstantiatePrefabAsync(key, new InstantiationParameters(parent, instantiateInWorldSpace));
 		}
 
 		/// <inheritdoc />
-		public async Task<GameObject> InstantiatePrefabAsync(string path, Vector3 position, Quaternion rotation, Transform parent)
+		public async Task<GameObject> InstantiateAsync(object key, Vector3 position, Quaternion rotation, Transform parent)
 		{
-			return await InstantiatePrefabAsync(path, new InstantiationParameters(position, rotation, parent));
+			return await InstantiatePrefabAsync(key, new InstantiationParameters(position, rotation, parent));
 		}
 
 		/// <inheritdoc />
 		public void UnloadAsset<T>(T asset)
 		{
 			Addressables.Release(asset);
-
-			var gameObject = asset as GameObject;
-			if (gameObject != null)
-			{
-				UnityEngine.Object.Destroy(gameObject);
-			}
 		}
 
 		/// <inheritdoc />
 		public async Task<Scene> LoadSceneAsync(string path, LoadSceneMode loadMode = LoadSceneMode.Single, bool activateOnLoad = true)
 		{
 			var operation = Addressables.LoadSceneAsync(path, loadMode, activateOnLoad);
-		
+
 			await operation.Task;
 
 			if (operation.Status != AsyncOperationStatus.Succeeded)
 			{
 				throw operation.OperationException;
-			
+
 			}
-		
+
 			return operation.Result.Scene;
 
 		}
@@ -82,13 +76,13 @@ namespace GameLovers.AddressablesExtensions
 		{
 			while (!operation.isDone)
 			{
-				await Task.Delay(100);
+				await Task.Yield();
 			}
 		}
-	
-		private async Task<GameObject> InstantiatePrefabAsync(string path, InstantiationParameters instantiateParameters = new InstantiationParameters())
+
+		private async Task<GameObject> InstantiatePrefabAsync(object key, InstantiationParameters instantiateParameters = new InstantiationParameters())
 		{
-			var operation = Addressables.InstantiateAsync(path, instantiateParameters);
+			var operation = Addressables.InstantiateAsync(key, instantiateParameters);
 
 			await operation.Task;
 
@@ -96,7 +90,7 @@ namespace GameLovers.AddressablesExtensions
 			{
 				throw operation.OperationException;
 			}
-			
+
 			return operation.Result;
 		}
 	}

--- a/Runtime/AssetLoaderUtils.cs
+++ b/Runtime/AssetLoaderUtils.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 // ReSharper disable CheckNamespace
 
-namespace GameLovers.AddressablesExtensions
+namespace GameLovers.AssetsImporter
 {
 	/// <summary>
 	/// Helper class with util improvements for loading methods
@@ -25,13 +25,13 @@ namespace GameLovers.AddressablesExtensions
 			var buckets = new TaskCompletionSource<Task<T>>[inputTasks.Count];
 			var results = new Task<Task<T>>[buckets.Length];
 			var nextTaskIndex = -1;
-			
-			for (var i = 0; i < buckets.Length; i++) 
+
+			for (var i = 0; i < buckets.Length; i++)
 			{
 				buckets[i] = new TaskCompletionSource<Task<T>>();
 				results[i] = buckets[i].Task;
 			}
-			
+
 			foreach (var inputTask in inputTasks)
 			{
 				inputTask.ContinueWith(Continuation, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);

--- a/Runtime/AssetReferenceScene.cs
+++ b/Runtime/AssetReferenceScene.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+// ReSharper disable once CheckNamespace
+
+namespace GameLovers.AssetsImporter
+{
+	/// <summary>
+	/// Implementation of a <see cref="AssetReference"/> for scenes
+	/// </summary>
+	[System.Serializable]
+	public class AssetReferenceScene : AssetReference
+	{
+		/// <summary>
+		/// Construct a new AssetReference object.
+		/// </summary>
+		/// <param name="guid">The guid of the asset.</param>
+		public AssetReferenceScene(string guid) : base(guid)
+		{
+		}
+ 
+		/// <inheritdoc/>
+		public override bool ValidateAsset(Object obj)
+		{
+#if UNITY_EDITOR
+			var type = obj.GetType();
+			return typeof(UnityEditor.SceneAsset).IsAssignableFrom(type);
+#else
+			return false;
+#endif
+		}
+ 
+		/// <inheritdoc/>
+		public override bool ValidateAsset(string path)
+		{
+#if UNITY_EDITOR
+			var type = UnityEditor.AssetDatabase.GetMainAssetTypeAtPath(path);
+			return typeof(UnityEditor.SceneAsset).IsAssignableFrom(type);
+#else
+			return false;
+#endif
+		}
+ 
+#if UNITY_EDITOR
+		/// <summary>
+		/// Type-specific override of parent editorAsset.  Used by the editor to represent the asset referenced.
+		/// </summary>
+		public new UnityEditor.SceneAsset editorAsset => (UnityEditor.SceneAsset)base.editorAsset;
+#endif
+	}
+}

--- a/Runtime/AssetReferenceScene.cs.meta
+++ b/Runtime/AssetReferenceScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e26b70092e4eb154280b53fccfd4eb59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/GameLovers.AddressablesExtensions.asmdef
+++ b/Runtime/GameLovers.AddressablesExtensions.asmdef
@@ -1,8 +1,11 @@
 {
     "name": "GameLovers.AddressablesExtensions",
+    "rootNamespace": "",
     "references": [
         "GUID:9e24947de15b9834991c9d8411ea37cf",
-        "GUID:84651a3751eca9349aac36a66bba901b"
+        "GUID:84651a3751eca9349aac36a66bba901b",
+        "GUID:22c6cdfa54ae844a9a9eda2f0014b020",
+        "GUID:e33762ba62cfd49478b7abd78f2b0e04"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/IAssetConfigsContainer.cs
+++ b/Runtime/IAssetConfigsContainer.cs
@@ -1,0 +1,129 @@
+using GameLovers.ConfigsProvider;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+// ReSharper disable once CheckNamespace
+
+namespace GameLovers.AssetsImporter
+{
+	/// <summary>
+	/// Defines a basic contract for Asset config with reference to weak link assets
+	/// </summary>
+	public abstract class AssetConfigScriptableObject : ScriptableObject
+	{
+		[SerializeField] private string _assetsFolderPath;
+
+		/// <summary>
+		/// Returns the folder path of the assets to be referenced in this container
+		/// </summary>
+		public string AssetsFolderPath
+		{
+			get => _assetsFolderPath;
+			set => _assetsFolderPath = value;
+		}
+	}
+
+	/// <inheritdoc cref="AssetConfigsScriptableObject{TKey,TValue}"/>
+	public abstract class AssetConfigsScriptableObject : AssetConfigScriptableObject
+	{
+		/// <summary>
+		/// Returns the asset type of <see cref="AssetReference"/> that this container is holding
+		/// </summary>
+		public abstract Type AssetType { get; }
+	}
+
+	/// <inheritdoc cref="IPairConfigsContainer{TKey,TValue}"/>
+	/// <remarks>
+	/// Use this configs container to hold the configs data of assets of the given <typeparamref name="TAsset"/>
+	/// mapped with the given <typeparamref name="TId"/>
+	/// </remarks>
+	public abstract class AssetConfigsScriptableObject<TId, TAsset> :
+		AssetConfigsScriptableObject, IPairConfigsContainer<TId, AssetReference>, ISerializationCallbackReceiver
+		where TId : struct
+	{
+		[SerializeField] private List<Pair<TId, AssetReference>> _configs = new();
+
+		/// <inheritdoc />
+		public override Type AssetType => typeof(TAsset);
+
+		/// <inheritdoc />
+		public List<Pair<TId, AssetReference>> Configs
+		{
+			get => _configs;
+			set => _configs = value;
+		}
+
+		/// <summary>
+		/// Requests the assets configs as a read only dictionary
+		/// </summary>
+		public IReadOnlyDictionary<TId, AssetReference> ConfigsDictionary { get; private set; }
+
+		/// <inheritdoc />
+		public void OnBeforeSerialize()
+		{
+			// Do Nothing
+		}
+
+		/// <inheritdoc />
+		public virtual void OnAfterDeserialize()
+		{
+			var dictionary = new Dictionary<TId, AssetReference>();
+
+			foreach (var config in Configs)
+			{
+				dictionary.Add(config.Key, config.Value);
+			}
+
+			ConfigsDictionary = new ReadOnlyDictionary<TId, AssetReference>(dictionary);
+		}
+	}
+
+	/// <inheritdoc cref="IPairConfigsContainer{TKey,TValue}"/>
+	/// <remarks>
+	/// Use this configs container to hold the configs data of assets of the given <typeparamref name="TAsset"/>
+	/// mapped with the given <typeparamref name="TId"/>
+	/// </remarks>
+	public abstract class AssetConfigsScriptableObjectSimple<TId, TAsset> :
+		AssetConfigsScriptableObject, IPairConfigsContainer<TId, TAsset>, ISerializationCallbackReceiver
+		where TId : struct
+	{
+		[SerializeField] private List<Pair<TId, TAsset>> _configs = new();
+
+		/// <inheritdoc />
+		public override Type AssetType => typeof(TAsset);
+
+		/// <inheritdoc />
+		public List<Pair<TId, TAsset>> Configs
+		{
+			get => _configs;
+			set => _configs = value;
+		}
+
+		/// <summary>
+		/// Requests the assets configs as a read only dictionary
+		/// </summary>
+		public IReadOnlyDictionary<TId, TAsset> ConfigsDictionary { get; private set; }
+
+		/// <inheritdoc />
+		public void OnBeforeSerialize()
+		{
+			// Do Nothing
+		}
+
+		/// <inheritdoc />
+		public virtual void OnAfterDeserialize()
+		{
+			var dictionary = new Dictionary<TId, TAsset>();
+
+			foreach (var config in Configs)
+			{
+				dictionary.Add(config.Key, config.Value);
+			}
+
+			ConfigsDictionary = new ReadOnlyDictionary<TId, TAsset>(dictionary);
+		}
+	}
+}

--- a/Runtime/IAssetConfigsContainer.cs.meta
+++ b/Runtime/IAssetConfigsContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68b0bbc5127235d47808a2e3f2957b00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/IAssetLoader.cs
+++ b/Runtime/IAssetLoader.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 // ReSharper disable CheckNamespace
 
-namespace GameLovers.AddressablesExtensions
+namespace GameLovers.AssetsImporter
 {
 	/// <summary>
 	/// This interface allows to wrap the asset loading scheme into an object reference
@@ -11,28 +11,28 @@ namespace GameLovers.AddressablesExtensions
 	public interface IAssetLoader
 	{
 		/// <summary>
-		/// Loads any asset of the given <typeparamref name="T"/> in the given <paramref name="path"/>.
+		/// Loads any asset of the given <typeparamref name="T"/> in the given <paramref name="key"/>.
 		/// To help the execution of this method is recommended to request the asset path from an <seealso cref="AddressableConfig"/>.
 		/// This method can be controlled in an async method and returns the asset loaded
 		/// </summary>
-		Task<T> LoadAssetAsync<T>(string path);
+		Task<T> LoadAssetAsync<T>(object key);
 
 		/// <summary>
-		/// Loads and instantiates the prefab in the given <paramref name="path"/> with the given <paramref name="parent"/>
+		/// Loads and instantiates the prefab in the given <paramref name="key"/> with the given <paramref name="parent"/>
 		/// and the given <paramref name="instantiateInWorldSpace"/> to preserve the instance transform relative to world
 		/// space or relative to the parent.
 		/// To help the execution of this method is recommended to request the asset path from an <seealso cref="AddressableConfig"/>.
 		/// This method can be controlled in an async method and returns the prefab instantiated
 		/// </summary>
-		Task<GameObject> InstantiatePrefabAsync(string path, Transform parent, bool instantiateInWorldSpace);
+		Task<GameObject> InstantiateAsync(object key, Transform parent, bool instantiateInWorldSpace);
 
 		/// <summary>
-		/// Loads and instantiates the prefab in the given <paramref name="path"/> with the given <paramref name="position"/>,
+		/// Loads and instantiates the prefab in the given <paramref name="key"/> with the given <paramref name="position"/>,
 		/// the given <paramref name="rotation"/> & the given <paramref name="parent"/>.
 		/// To help the execution of this method is recommended to request the asset path from an <seealso cref="AddressableConfig"/>.
 		/// This method can be controlled in an async method and returns the prefab instantiated
 		/// </summary>
-		Task<GameObject> InstantiatePrefabAsync(string path, Vector3 position, Quaternion rotation, Transform parent);
+		Task<GameObject> InstantiateAsync(object key, Vector3 position, Quaternion rotation, Transform parent);
 
 		/// <summary>
 		/// Unloads the given <paramref name="asset"/> from the game memory.

--- a/Runtime/ISceneLoader.cs
+++ b/Runtime/ISceneLoader.cs
@@ -3,7 +3,7 @@ using UnityEngine.SceneManagement;
 
 // ReSharper disable CheckNamespace
 
-namespace GameLovers.AddressablesExtensions
+namespace GameLovers.AssetsImporter
 {
 	/// <summary>
 	/// This interface allows to wrap the scene loading scheme into an object reference

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "unity": "2021.4",
   "license": "MIT",
-  "description": "This package extends the loading functionality of assets from Unity Addressables with the possibility to generate new info about each asset addressable.\n\nThe asset info generator can be executed in Tools > Generate AddressableIds",
+  "description": "This package extends the loading functionality of assets from Unity Addressables with the possibility to generate new info about each asset addressable.\nThis package also gives flexibitlity to extend the asset import pipeline to have many scriptable objects to include weaklinks of every asset in the game, separated by type.\n\nThe asset info generator can be executed in Tools > Generate AddressableIds",
   "type": "library",
   "hideInEditor": false,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
-  "name": "com.gamelovers.addressablesextensions",
-  "displayName": "Addressables Extensions",
-  "version": "0.1.1",
-  "unity": "2019.3",
+  "name": "com.gamelovers.assetsimporter",
+  "displayName": "Assets Importer",
+  "version": "0.2.0",
+  "unity": "2021.4",
   "description": "This package extends the loading functionality of assets from Unity Addressables with the possibility to generate new info about each asset addressable.\n\nThe asset info generator can be executed in Tools > Generate AddressableIds",
   "type": "library",
   "hideInEditor": false,
   "dependencies": {
-    "com.unity.addressables": "1.15.1"
+    "com.unity.addressables": "1.15.1",
+    "com.gamelovers.dataextensions": "0.5.0",
+    "com.gamelovers.configsprovider": "0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "com.gamelovers.assetsimporter",
-  "displayName": "Assets Importer",
+  "displayName": "Unity Assets Importer",
+  "author": "Miguel Tomas",
   "version": "0.2.0",
   "unity": "2021.4",
+  "license": "MIT",
   "description": "This package extends the loading functionality of assets from Unity Addressables with the possibility to generate new info about each asset addressable.\n\nThe asset info generator can be executed in Tools > Generate AddressableIds",
   "type": "library",
   "hideInEditor": false,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `AssetsImporter` tool for importing assets data in Unity, accessible from the Unity Editor's Tools menu.
- New Feature: Added `AssetReferenceScene` class to validate scene assets.
- Refactor: Updated `AddressableIdsGenerator` to include new namespaces, enums, and lookup methods. Improved asset filtering based on labels.
- Refactor: Changed parameter type of `LoadAssetAsync` and `InstantiateAsync` methods from `string` to `object` in `AddressablesAssetLoader`.
- Refactor: Renamed namespace from "GameLovers.AddressablesExtensions" to "GameLovers.AssetsImporter" across multiple files.
- Bug Fix: Prevented destruction of GameObjects in `UnloadAsset` method of `AddressablesAssetLoader`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->